### PR TITLE
Version 0.10.0(or later) Compatible

### DIFF
--- a/src/ofxReflectionRefraction.h
+++ b/src/ofxReflectionRefraction.h
@@ -89,7 +89,7 @@ class ofxReflectionRefraction : public ofBaseApp{
             tra.preMultTranslate(translate);
             glass.begin();
             glass.setUniformMatrix4f("u_viewProjectionMatrix",cam.getProjectionMatrix());
-            glass.setUniformMatrix4f("u_modelMatrix",cam.getModelViewMatrix()*tra);
+            glass.setUniformMatrix4f("u_modelMatrix",tra*cam.getModelViewMatrix());
             glass.setUniformMatrix3f("u_normalMatrix",mat4ToMat3(ofGetCurrentNormalMatrix()));
             glass.setUniform4f("u_camera",cam.getGlobalPosition().x,
                                           cam.getGlobalPosition().y,


### PR DESCRIPTION
I ran the example, but got the following error.

```
Invalid operands to binary expression ('glm::mat4' (aka 'mat<4, 4, float, defaultp>') and 'ofMatrix4x4')
```

This seems to be caused by the fact that ofCamera::getModelViewMatrix() is returned as glm type since oF version 0.10.0.
So I switched the multiplication around.

```diff
-    glass.setUniformMatrix4f("u_modelMatrix",cam.getModelViewMatrix()*tra);
+    glass.setUniformMatrix4f("u_modelMatrix",tra*cam.getModelViewMatrix());
```